### PR TITLE
Fix a Python syntax error

### DIFF
--- a/netbox-prometheus-sd.py
+++ b/netbox-prometheus-sd.py
@@ -64,7 +64,7 @@ def main(args):
 
     json.dump(targets, output, indent=4)
 
-    output.close()Z
+    output.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A dangling character was causing a syntax error in netbox-prometheus-sd.py